### PR TITLE
programs.sh: fix bug when path contains symbolic links

### DIFF
--- a/programs.sh
+++ b/programs.sh
@@ -3,14 +3,13 @@
 fn nash_complete_program(line, pos) {
 	var paths <= getpaths()
 	var choice, status <= (
-		find $paths -maxdepth 1 -type f
-					>[2=] |
-		grep -v find |
+		find $paths -maxdepth 1 -type f -follow
+						>[2=] |
 		sed "s#/.*/##g" |
-		sort -u |
-		-fzf -q "^"+$line
-				-1
-				-0
+		sort --unique |
+		fzf --query "^"+$line
+				--select-1
+				--exit-0
 				--header "Looking for system-wide binaries"
 				--prompt "(λ programs)>"
 				--reverse


### PR DESCRIPTION
Hello there, 

When exists a symbolic link in the path the autocomplete don't return the expect result. 

```bash
~ λ> ls -l /usr/sbin/iptables
lrwxrwxrwx. 1 root root 26 Sep 15 09:50 /usr/sbin/iptables -> /etc/alternatives/iptables

~ λ> ls -l /etc/alternatives/iptables 
lrwxrwxrwx. 1 root root 25 Sep 15 09:50 /etc/alternatives/iptables -> /usr/sbin/iptables-legacy
```

![image](https://user-images.githubusercontent.com/2488125/97175846-e3c54900-1772-11eb-91e1-5cface7b4a8d.png)

This PR add the option `-follow` to find command to follow symbolic link and fix that issue. 

![image](https://user-images.githubusercontent.com/2488125/97176703-17ed3980-1774-11eb-9df1-74a49e1da550.png)


Thanks.
