### PR TITLE
Fix bug when dir on PATH var doesn't exist

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -1,10 +1,5 @@
 # common functions
 
-fn cleanpath() {
-	var ret <= echo $PATH | sed "s/^://g" | sed "s/:$//g"
-
-	return $ret
-}
 
 fn trim(value) {
 	var value <= echo $value | tr -d "\n"
@@ -17,14 +12,6 @@ fn diffword(complete, line) {
 
 	return $diff
 }
-
-var path <= cleanpath()
-var paths <= split($path, ":")
-
-fn getpaths() {
-	return $paths
-}
-
 
 fn join(list, sep) {
 	var str = ""

--- a/programs.sh
+++ b/programs.sh
@@ -32,7 +32,7 @@ fn _nash_complete_programs_paths() {
         var validPaths = ()
 
         for path in $paths {
-                var _, status <= ls $path
+                var _, status <= ls $path >[2=] /dev/null
                 if $status == "0" {
                         validPaths <= append($validPaths, $path)
                 }

--- a/programs.sh
+++ b/programs.sh
@@ -1,7 +1,7 @@
 # autocomplete of system-wide binaries
 
 fn nash_complete_program(line, pos) {
-	var paths <= getpaths()
+	var paths <= _nash_complete_programs_paths()
 	var choice, status <= (
 		find $paths -maxdepth 1 -type f
 					>[2=] |
@@ -24,4 +24,24 @@ fn nash_complete_program(line, pos) {
 	choice <= diffword($choice, $line)
 
 	return ($choice+" " "0")
+}
+
+
+fn _nash_complete_programs_paths() {
+        var path <= _nash_complete_programs_clean_path()
+        var paths <= split($path, ":")
+        var validPaths = ()
+
+        for path in $paths {
+                var _, status <= ls $path
+                if $status == "0" {
+                        validPaths <= append($validPaths, $path)
+                }
+        }
+	return $validPaths
+}
+
+fn _nash_complete_programs_clean_path() {
+	var ret <= echo $PATH | sed "s/^://g" | sed "s/:$//g"
+	return $ret
 }


### PR DESCRIPTION
When some dir on the PATH env var didn't exist it would bug autocompletion. Also changes on the PATH env var were not reflected on the autocompletion, which kinda mislead-ed us when debugging the issue, so now we always load the env PATH on autocompletion instead of doing it only one when the file is imported.